### PR TITLE
chore: Upgrade Flutter SDK to version 3.44.0

### DIFF
--- a/.github/workflows/deploy_web_dev.yaml
+++ b/.github/workflows/deploy_web_dev.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: subosito/flutter-action@v2.23.0
         with:
-          flutter-version: "3.41.9"
+          flutter-version: "3.44.0"
           channel: "stable"
       - run: flutter packages get
       - run: flutter build web -t lib/main.dart

--- a/.github/workflows/deploy_web_prod.yaml
+++ b/.github/workflows/deploy_web_prod.yaml
@@ -17,7 +17,7 @@ jobs:
           ref: ${{ github.event.inputs.version }}
       - uses: subosito/flutter-action@v2.23.0
         with:
-          flutter-version: "3.41.9"
+          flutter-version: "3.44.0"
           channel: "stable"
       - run: flutter packages get
       - run: flutter build web -t lib/main.dart

--- a/.github/workflows/validate_pr.yaml
+++ b/.github/workflows/validate_pr.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2.23.0
         with:
-          flutter-version: "3.41.9"
+          flutter-version: "3.44.0"
           channel: "stable"
       - name: Get Flutter Packages
         run: flutter pub get
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2.23.0
         with:
-          flutter-version: "3.41.9"
+          flutter-version: "3.44.0"
           channel: "stable"
       - name: Setup Translations Cleaner
         run: flutter pub global activate translations_cleaner
@@ -82,7 +82,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2.23.0
         with:
-          flutter-version: "3.41.9"
+          flutter-version: "3.44.0"
           channel: "stable"
       - name: Get Flutter Packages
         run: flutter pub get

--- a/.github/workflows/version_increment.yaml
+++ b/.github/workflows/version_increment.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2.23.0
         with:
-          flutter-version: "3.41.9"
+          flutter-version: "3.44.0"
           channel: "stable"
 
       - name: Install standard-version

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 version: 0.0.32
 environment:
   sdk: ">=3.8.0 <4.0.0"
-  flutter: 3.41.9
+  flutter: 3.44.0
 dependencies:
   # Not actually used, but needed to suppress warnings. Gets tree shaken out at build time.
   cupertino_icons: ^1.0.9


### PR DESCRIPTION
## Summary
This pull request upgrades the Flutter SDK version from 3.41.9 to 3.44.0 across all CI/CD workflows and project configuration.

## Changes Made
- Updated Flutter version in `pubspec.yaml` environment constraint from 3.41.9 to 3.44.0
- Updated Flutter version in all GitHub Actions workflows:
  - `validate_pr.yaml` (3 occurrences across different jobs)
  - `deploy_web_dev.yaml`
  - `deploy_web_prod.yaml`
  - `version_increment.yaml`

## Details
This is a minor version upgrade that ensures consistency across the development environment, CI/CD pipelines, and project dependencies. All workflows now use the same Flutter version (3.44.0) on the stable channel, reducing potential version mismatch issues between local development and automated builds.

https://claude.ai/code/session_01D8kFGfvMNGqeyuEJs3SWj6