### PR TITLE
ci: fix shell command grouping in version increment workflow

### DIFF
--- a/.github/workflows/version_increment.yaml
+++ b/.github/workflows/version_increment.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Update version
         run: |
           yq eval '.version = "${{ env.tag }}"' -i app/pubspec.yaml
-          cd app && flutter packages get && flutter pub run build_runner build --delete-conflicting-outputs
+          (cd app && flutter packages get && flutter pub run build_runner build --delete-conflicting-outputs)
           git add app/pubspec.yaml
           git add docs/RELEASE_NOTES.md
           git add app/lib/src/version.dart


### PR DESCRIPTION
## Summary

Fixed a shell command grouping issue in the version increment workflow. The `flutter packages get` and `flutter pub run build_runner build` commands are now properly grouped using parentheses to ensure they execute in the `app` directory context, rather than only the `cd app` command being scoped.

This prevents potential issues where the build_runner command might execute in the wrong directory if the previous command fails or if there are shell interpretation issues.

## Test Plan

The workflow will be validated when the next version increment is triggered. The CI system will verify that the commands execute successfully in the correct directory.

https://claude.ai/code/session_01RQgSbZxoGmESYPBWgtv31W