### PR TITLE
ci: wrap flutter build steps in subshells to preserve working directory

### DIFF
--- a/.github/.cspell/dev_dictionary.txt
+++ b/.github/.cspell/dev_dictionary.txt
@@ -1,5 +1,6 @@
 ltrb
 notmain
+subshell
 xcassets
 xcode
 xcworkspace

--- a/.github/workflows/version_increment.yaml
+++ b/.github/workflows/version_increment.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Update version
         run: |
           yq eval '.version = "${{ env.tag }}"' -i app/pubspec.yaml
-          cd app && flutter packages get && flutter pub run build_runner build --delete-conflicting-outputs
+          (cd app && flutter packages get && flutter pub run build_runner build --delete-conflicting-outputs)
           git add app/pubspec.yaml
           git add docs/RELEASE_NOTES.md
           git add app/lib/src/version.dart

--- a/.github/workflows/version_increment.yaml
+++ b/.github/workflows/version_increment.yaml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Make Web Build Asset
         run: |
-          cd app && flutter build web -t lib/main.dart
+          (cd app && flutter build web -t lib/main.dart)
           zip -r web_${{ env.tag }}.zip app/build/web
 
       - name: Set up Java
@@ -112,12 +112,12 @@ jobs:
 
       - name: Make Android APK Build Asset
         run: |
-          cd app && flutter build apk --release
+          (cd app && flutter build apk --release)
           cp app/build/app/outputs/flutter-apk/app-release.apk app-release_${{ env.tag }}.apk
 
       - name: Make Android App Bundle Build Asset
         run: |
-          cd app && flutter build appbundle --release
+          (cd app && flutter build appbundle --release)
           cp app/build/app/outputs/bundle/release/app-release.aab app-release_${{ env.tag }}.aab
 
       - name: Make GitHub release


### PR DESCRIPTION
## Summary

- `cd app` in a `run:` block persists for all subsequent commands in that block, causing paths like `app/build/web` to resolve as `app/app/build/web`
- Wrapped the flutter build commands for web, APK, and AAB in subshells `(cd app && ...)` so the directory change doesn't leak to the `zip`/`cp` commands that follow

## Test plan

- [ ] Trigger the Version Increment workflow and verify the web, APK, and AAB build assets are created and attached to the release successfully

https://claude.ai/code/session_01RQgSbZxoGmESYPBWgtv31W

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQgSbZxoGmESYPBWgtv31W)_