### PR TITLE
chore: address build warnings from version increment workflow

### DIFF
--- a/.github/workflows/version_increment.yaml
+++ b/.github/workflows/version_increment.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Update version
         run: |
           yq eval '.version = "${{ env.tag }}"' -i app/pubspec.yaml
-          (cd app && flutter packages get && flutter pub run build_runner build --delete-conflicting-outputs)
+          (cd app && flutter packages get && flutter pub run build_runner build)
           git add app/pubspec.yaml
           git add docs/RELEASE_NOTES.md
           git add app/lib/src/version.dart

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
+    id "org.jetbrains.kotlin.android"
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id "dev.flutter.flutter-gradle-plugin"
 }

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -14,10 +14,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
-    }
-
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId = "com.tomarra.curling_scoreboard_flutter"
@@ -40,4 +36,10 @@ android {
 
 flutter {
     source = "../.."
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
 }

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "com.android.application"
-    id "org.jetbrains.kotlin.android"
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id "dev.flutter.flutter-gradle-plugin"
 }

--- a/app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/app/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-all.zip

--- a/app/android/settings.gradle
+++ b/app/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "com.android.application" version "8.11.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## Summary

Addresses all actionable warnings from the 0.0.34 build log before Flutter drops support for these versions.

| What | Before | After | Minimum required |
|---|---|---|---|
| Gradle | 8.7.0 | 8.14.1 | 8.14.0 |
| Android Gradle Plugin | 8.6.0 | 8.11.1 | 8.11.1 |
| Kotlin | 2.1.0 | 2.2.20 | 2.2.20 |
| `--delete-conflicting-outputs` | present (silently ignored) | removed | — |

## Kotlin Gradle Plugin migration

The build log warned that `app/android/app/build.gradle` explicitly applies the Kotlin Gradle Plugin, which will cause build failures in future versions of Flutter. The `dev.flutter.flutter-gradle-plugin` now applies Kotlin automatically.

**Migration guide:** https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers

All steps from the guide have been completed in `app/android/app/build.gradle`:

| Step | Status |
|---|---|
| Remove `id "kotlin-android"` from the `plugins` block | ✅ Done |
| Remove the `kotlinOptions { }` block from inside `android { }` | ✅ Done |
| Add top-level `kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_17 } }` | ✅ Done |

Note: `kotlin-android` is a shorthand alias for `org.jetbrains.kotlin.android` — they are the same plugin, so renaming it would not fix the warning. The correct fix is removal.

## Test plan

- [ ] Trigger the Version Increment workflow and confirm no Gradle/AGP/Kotlin deprecation warnings appear in the APK/AAB build steps

https://claude.ai/code/session_01RQgSbZxoGmESYPBWgtv31W