### PR TITLE
feat: add dev data seed script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,76 +1,55 @@
 # Curling Scoreboard
 
-A simple Curling Scoreboard, written in Flutter, meant to be used in any curling club that has an electronic scoreboard.
+A simple Curling Scoreboard, written in Flutter, meant to be used in any curling club that has an electronic scoreboard. Allows for live polling of scores as well as historical games as needed.
 
 ## Project Setup
 
 ### Prerequisites
 
-- [Flutter 3.44.0](https://docs.flutter.dev/get-started/install) (stable channel)
-- [Firebase CLI](https://firebase.google.com/docs/cli) (`npm install -g firebase-tools`)
-- [Google Cloud SDK](https://cloud.google.com/sdk/docs/install) (`gcloud`) for local credentials
-- [VS Code](https://code.visualstudio.com/) with the [Dart extension](https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code)
+- [Flutter](https://docs.flutter.dev/get-started/install) - typically latest stable
+- [Firebase CLI](https://firebase.google.com/docs/cli) - `npm install -g firebase-tools`
+- [Google Cloud SDK](https://cloud.google.com/sdk/docs/install) - `gcloud` for local credentials
 
 ### First-time setup
 
 1. Clone the repo and open the root folder in VS Code.
 
 2. Install Flutter dependencies:
+
    ```bash
    cd app
    flutter pub get
    ```
 
 3. Authenticate with Firebase:
+
    ```bash
    firebase login
    gcloud auth application-default login
    ```
 
 4. Select the dev project:
+
    ```bash
    firebase use default   # targets curling-scoreboard-dev
-   ```
-
-5. Deploy Firestore rules and indexes to dev (first time only, or after changes):
-   ```bash
-   cd app
-   firebase deploy --only firestore
    ```
 
 ### Running locally
 
 Open the project in VS Code and use the **Launch Web** run configuration (`.vscode/launch.json`). This launches the app in Chrome against the dev Firebase project.
 
-Alternatively, from the command line:
-```bash
-cd app
-flutter run -d chrome
-```
-
-### Running tests
-
-```bash
-cd app
-flutter test
-```
-
 ---
 
-## Seeding Dev Data
+### Seeding Dev Data
 
 A Node.js seed script populates the dev Firestore with realistic test data:
 
-- **Windy City Curling** — 3 sheets
-- **Milwaukee Curling Club** — 5 sheets
-- **3 completed game records per sheet**, spread across the past 3 weeks
-
-### Prerequisites
+#### Prerequisites
 
 - Node.js 18+
 - Authenticated via `gcloud auth application-default login` (see setup above)
 
-### Running the seed script
+#### Running the seed script
 
 ```bash
 cd scripts
@@ -79,6 +58,7 @@ node seed-dev.js
 ```
 
 The script targets `curling-scoreboard-dev` by default. To target a different project:
+
 ```bash
 FIREBASE_PROJECT_ID=my-other-project node seed-dev.js
 ```

--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ A simple Curling Scoreboard, written in Flutter, meant to be used in any curling
 
 Open the project in VS Code and use the **Launch Web** run configuration (`.vscode/launch.json`). This launches the app in Chrome against the dev Firebase project.
 
----
-
 ### Seeding Dev Data
 
 A Node.js seed script populates the dev Firestore with realistic test data:

--- a/README.md
+++ b/README.md
@@ -4,9 +4,88 @@ A simple Curling Scoreboard, written in Flutter, meant to be used in any curling
 
 ## Project Setup
 
-This project is a basic [Flutter](http://www.flutter.dev) application so [environment setup](https://docs.flutter.dev/get-started/install) can be found and followed on the main Flutter developer site.
+### Prerequisites
 
-After cloning the repo and opening the project in [VSCode](https://code.visualstudio.com/) you should be able to run the `Launch Web` target to see everything up and working.
+- [Flutter 3.44.0](https://docs.flutter.dev/get-started/install) (stable channel)
+- [Firebase CLI](https://firebase.google.com/docs/cli) (`npm install -g firebase-tools`)
+- [Google Cloud SDK](https://cloud.google.com/sdk/docs/install) (`gcloud`) for local credentials
+- [VS Code](https://code.visualstudio.com/) with the [Dart extension](https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code)
+
+### First-time setup
+
+1. Clone the repo and open the root folder in VS Code.
+
+2. Install Flutter dependencies:
+   ```bash
+   cd app
+   flutter pub get
+   ```
+
+3. Authenticate with Firebase:
+   ```bash
+   firebase login
+   gcloud auth application-default login
+   ```
+
+4. Select the dev project:
+   ```bash
+   firebase use default   # targets curling-scoreboard-dev
+   ```
+
+5. Deploy Firestore rules and indexes to dev (first time only, or after changes):
+   ```bash
+   cd app
+   firebase deploy --only firestore
+   ```
+
+### Running locally
+
+Open the project in VS Code and use the **Launch Web** run configuration (`.vscode/launch.json`). This launches the app in Chrome against the dev Firebase project.
+
+Alternatively, from the command line:
+```bash
+cd app
+flutter run -d chrome
+```
+
+### Running tests
+
+```bash
+cd app
+flutter test
+```
+
+---
+
+## Seeding Dev Data
+
+A Node.js seed script populates the dev Firestore with realistic test data:
+
+- **Windy City Curling** — 3 sheets
+- **Milwaukee Curling Club** — 5 sheets
+- **3 completed game records per sheet**, spread across the past 3 weeks
+
+### Prerequisites
+
+- Node.js 18+
+- Authenticated via `gcloud auth application-default login` (see setup above)
+
+### Running the seed script
+
+```bash
+cd scripts
+npm install
+node seed-dev.js
+```
+
+The script targets `curling-scoreboard-dev` by default. To target a different project:
+```bash
+FIREBASE_PROJECT_ID=my-other-project node seed-dev.js
+```
+
+The script is **idempotent for clubs and sheets** — re-running it won't create duplicates there. Each run does add a new set of game documents per sheet, so run it once unless you intentionally want more game history.
+
+---
 
 ## Deployments
 
@@ -16,10 +95,10 @@ When a pull request is opened, the [validate_pr](https://github.com/CloudgateStu
 
 ### Dev System
 
-Any push to `main` automatically triggers the [deploy_web_dev](https://github.com/CloudgateStudios/curling_scoreboard/actions/workflows/deploy_web_dev.yaml) workflow, which builds and deploys to the live dev environment.
+Any push to `main` automatically triggers the [deploy_web_dev](https://github.com/CloudgateStudios/curling_scoreboard/actions/workflows/deploy_web_dev.yaml) workflow, which builds and deploys the app and Firestore configuration to the live dev environment.
 
 ### Prod System
 
-You first need to do ensure you have a new tagged version. This is handled by the [version_increment](https://github.com/CloudgateStudios/curling_scoreboard/actions/workflows/version_increment.yaml) workflow. This will automatically read the commits, create the [changelog](https://github.com/CloudgateStudios/curling_scoreboard/blob/main/docs/CHANGELOG.md) and [release notes](https://github.com/CloudgateStudios/curling_scoreboard/blob/main/docs/RELEASE_NOTES.md) and commit it all back to the `main` branch.
+You first need to ensure you have a new tagged version. This is handled by the [version_increment](https://github.com/CloudgateStudios/curling_scoreboard/actions/workflows/version_increment.yaml) workflow. This will automatically read the commits, create the [changelog](https://github.com/CloudgateStudios/curling_scoreboard/blob/main/docs/CHANGELOG.md) and [release notes](https://github.com/CloudgateStudios/curling_scoreboard/blob/main/docs/RELEASE_NOTES.md) and commit it all back to the `main` branch.
 
 Production deploys are manual. Go to the [deploy_web_prod](https://github.com/CloudgateStudios/curling_scoreboard/actions/workflows/deploy_web_prod.yaml) action, click "Run Workflow", and enter the version tag to deploy (e.g. `0.0.34`). The workflow checks out that exact tag and deploys it to the live prod environment.

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.json.key
+service-account*.json

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "curling-scoreboard-scripts",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "seed-dev": "node seed-dev.js"
+  },
+  "dependencies": {
+    "firebase-admin": "^12.0.0"
+  }
+}

--- a/scripts/seed-dev.js
+++ b/scripts/seed-dev.js
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * Seed script for the dev Firestore environment.
+ *
+ * Prerequisites:
+ *   1. Install dependencies: `npm install` (inside scripts/)
+ *   2. Authenticate: `gcloud auth application-default login`
+ *      OR set GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+ *   3. Run: `node seed-dev.js`
+ *
+ * What it creates:
+ *   - 2 clubs (Windy City Curling, Milwaukee Curling Club)
+ *   - 3 sheets under Windy City, 5 sheets under Milwaukee
+ *   - 3 completed game records per sheet
+ *
+ * The script is idempotent for clubs and sheets (uses set with merge).
+ * Running it again appends additional game documents to each sheet.
+ */
+
+const admin = require('firebase-admin');
+
+const PROJECT_ID = process.env.FIREBASE_PROJECT_ID || 'curling-scoreboard-dev';
+
+admin.initializeApp({ projectId: PROJECT_ID });
+
+const db = admin.firestore();
+const { Timestamp } = admin.firestore;
+
+// ---------------------------------------------------------------------------
+// Club + sheet definitions
+// ---------------------------------------------------------------------------
+
+const CLUBS = [
+  {
+    id: 'windy-city-curling',
+    name: 'Windy City Curling',
+    sheets: [
+      { id: 'sheet-1', name: 'Sheet 1' },
+      { id: 'sheet-2', name: 'Sheet 2' },
+      { id: 'sheet-3', name: 'Sheet 3' },
+    ],
+  },
+  {
+    id: 'milwaukee-curling',
+    name: 'Milwaukee Curling Club',
+    sheets: [
+      { id: 'sheet-1', name: 'Sheet 1' },
+      { id: 'sheet-2', name: 'Sheet 2' },
+      { id: 'sheet-3', name: 'Sheet 3' },
+      { id: 'sheet-4', name: 'Sheet 4' },
+      { id: 'sheet-5', name: 'Sheet 5' },
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Game templates
+// Each entry: { team (1 or 2), score }
+// team 1 = "Red", team 2 = "Yellow"
+// score 0 with team 1 = blank end (Red retains hammer in normal game)
+// ---------------------------------------------------------------------------
+
+const GAME_TEMPLATES = [
+  // Game A — Red wins 8-5, Red has hammer first end
+  {
+    team1HasHammerFirstEnd: true,
+    durationMinutes: 118,
+    ends: [
+      { team: 1, score: 2 }, // end 1
+      { team: 2, score: 1 }, // end 2
+      { team: 1, score: 2 }, // end 3
+      { team: 2, score: 1 }, // end 4
+      { team: 1, score: 3 }, // end 5
+      { team: 2, score: 1 }, // end 6
+      { team: 1, score: 1 }, // end 7
+      { team: 2, score: 2 }, // end 8
+    ],
+  },
+  // Game B — Yellow wins 8-6, Yellow has hammer first end
+  {
+    team1HasHammerFirstEnd: false,
+    durationMinutes: 124,
+    ends: [
+      { team: 2, score: 2 }, // end 1
+      { team: 1, score: 1 }, // end 2
+      { team: 2, score: 3 }, // end 3
+      { team: 1, score: 0 }, // end 4 — blank
+      { team: 2, score: 2 }, // end 5
+      { team: 1, score: 3 }, // end 6
+      { team: 2, score: 1 }, // end 7
+      { team: 1, score: 2 }, // end 8
+    ],
+  },
+  // Game C — Red wins 6-4, Yellow has hammer first end
+  {
+    team1HasHammerFirstEnd: false,
+    durationMinutes: 109,
+    ends: [
+      { team: 2, score: 2 }, // end 1
+      { team: 1, score: 3 }, // end 2
+      { team: 2, score: 1 }, // end 3
+      { team: 1, score: 1 }, // end 4
+      { team: 1, score: 0 }, // end 5 — blank
+      { team: 2, score: 1 }, // end 6
+      { team: 1, score: 2 }, // end 7
+      { team: 1, score: 0 }, // end 8 — blank, still Red wins 6-4
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildGameDoc(template, startedAt) {
+  const team1Name = 'Red';
+  const team2Name = 'Yellow';
+  const secondsPerEnd = (template.durationMinutes * 60) / 8;
+
+  const ends = template.ends.map((entry, i) => ({
+    endNumber: i + 1,
+    scoringTeam: entry.score === 0 ? null : (entry.team === 1 ? team1Name : team2Name),
+    score: entry.score,
+    gameTimeInSeconds: Math.round(secondsPerEnd * (i + 1)),
+  }));
+
+  const team1Score = ends
+    .filter((e) => e.scoringTeam === team1Name)
+    .reduce((sum, e) => sum + e.score, 0);
+  const team2Score = ends
+    .filter((e) => e.scoringTeam === team2Name)
+    .reduce((sum, e) => sum + e.score, 0);
+
+  const finishedAt = new Date(startedAt.getTime() + template.durationMinutes * 60 * 1000);
+
+  return {
+    startedAt: Timestamp.fromDate(startedAt),
+    finishedAt: Timestamp.fromDate(finishedAt),
+    numberOfEnds: 8,
+    team1: {
+      name: team1Name,
+      totalScore: team1Score,
+      hadLastStoneFirstEnd: template.team1HasHammerFirstEnd,
+    },
+    team2: {
+      name: team2Name,
+      totalScore: team2Score,
+      hadLastStoneFirstEnd: !template.team1HasHammerFirstEnd,
+    },
+    ends,
+  };
+}
+
+// Spread the 3 games across the past 3 weeks, one per week, starting ~7pm.
+function gameStartDates(baseOffsetDays) {
+  const dates = [];
+  for (let week = 0; week < 3; week++) {
+    const d = new Date();
+    d.setDate(d.getDate() - (21 - week * 7) - baseOffsetDays);
+    d.setHours(19, 0, 0, 0);
+    dates.push(d);
+  }
+  return dates;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function seed() {
+  console.log(`Seeding project: ${PROJECT_ID}\n`);
+
+  for (const club of CLUBS) {
+    const clubRef = db.collection('clubs').doc(club.id);
+    await clubRef.set({ name: club.name }, { merge: true });
+    console.log(`Club: ${club.name}`);
+
+    for (let si = 0; si < club.sheets.length; si++) {
+      const sheet = club.sheets[si];
+      const sheetRef = clubRef.collection('sheets').doc(sheet.id);
+      await sheetRef.set({ name: sheet.name }, { merge: true });
+      console.log(`  Sheet: ${sheet.name}`);
+
+      // Stagger start dates slightly per sheet so games don't all overlap.
+      const starts = gameStartDates(si);
+
+      for (let gi = 0; gi < GAME_TEMPLATES.length; gi++) {
+        const doc = buildGameDoc(GAME_TEMPLATES[gi], starts[gi]);
+        await sheetRef.collection('games').add(doc);
+        const winner = doc.team1.totalScore > doc.team2.totalScore ? doc.team1.name : doc.team2.name;
+        console.log(
+          `    Game ${gi + 1}: ${doc.team1.name} ${doc.team1.totalScore} – ${doc.team2.totalScore} ${doc.team2.name} (${winner} wins)`,
+        );
+      }
+    }
+
+    console.log('');
+  }
+
+  console.log('Done.');
+}
+
+seed().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds `scripts/seed-dev.js` — a Node.js script that populates the dev Firestore with realistic test data
- Creates **Windy City Curling** (3 sheets) and **Milwaukee Curling Club** (5 sheets)
- Seeds **3 completed game records per sheet** spread across the past 3 weeks

## Data shape

Each game follows the existing `saveCompletedGame` document structure:
- `startedAt` / `finishedAt` timestamps
- `numberOfEnds: 8`
- `team1` / `team2` with `name`, `totalScore`, `hadLastStoneFirstEnd`
- `ends[]` with `endNumber`, `scoringTeam`, `score`, `gameTimeInSeconds`

Game outcomes per sheet (same 3 templates, staggered dates):
| Game | Result |
|------|--------|
| 1 | Red 8 – 5 Yellow |
| 2 | Yellow 8 – 6 Red |
| 3 | Red 6 – 4 Yellow |

## Test plan

- [ ] `cd scripts && npm install`
- [ ] `gcloud auth application-default login` (or set `GOOGLE_APPLICATION_CREDENTIALS`)
- [ ] `node seed-dev.js` — confirm output shows all clubs/sheets/games
- [ ] Open Firestore Console for `curling-scoreboard-dev` and verify documents created under `clubs/`

https://claude.ai/code/session_01VNtuZwXUuyodaiEAHW6BbF

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNtuZwXUuyodaiEAHW6BbF)_