### PR TITLE
ci: add --force flag to functions deploy in dev and prod workflows

### DIFF
--- a/.github/workflows/deploy_web_dev.yaml
+++ b/.github/workflows/deploy_web_dev.yaml
@@ -41,4 +41,4 @@ jobs:
       - name: Build Functions
         run: cd functions && npm run build
       - name: Deploy Firestore and Functions
-        run: npx firebase-tools@latest deploy --only firestore,functions --project curling-scoreboard-dev
+        run: npx firebase-tools@latest deploy --only firestore,functions --force --project curling-scoreboard-dev

--- a/.github/workflows/deploy_web_prod.yaml
+++ b/.github/workflows/deploy_web_prod.yaml
@@ -45,4 +45,4 @@ jobs:
       - name: Build Functions
         run: cd functions && npm run build
       - name: Deploy Firestore and Functions
-        run: npx firebase-tools@latest deploy --only firestore,functions --project curling-scoreboard-prod
+        run: npx firebase-tools@latest deploy --only firestore,functions --force --project curling-scoreboard-prod


### PR DESCRIPTION
## Summary

- Adds `--force` to the `firebase deploy` command in `deploy_web_dev.yaml` and `deploy_web_prod.yaml`
- Prevents the cleanup policy error that exits with code 1 even when the function deploys successfully
- Matches the same fix already applied to `validate_pr.yaml`

## Test plan

- [ ] Merge and confirm the next push-to-main deploy run completes without the cleanup policy error
- [ ] Confirm prod workflow (`workflow_dispatch`) also completes cleanly

https://claude.ai/code/session_01VNtuZwXUuyodaiEAHW6BbF

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNtuZwXUuyodaiEAHW6BbF)_