### PR TITLE
ci: inject google-services.json from secret before Android builds

### DIFF
--- a/.github/workflows/version_increment.yaml
+++ b/.github/workflows/version_increment.yaml
@@ -110,6 +110,9 @@ jobs:
           java-version: 17
           distribution: "temurin"
 
+      - name: Setup Google Services for Android
+        run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > app/android/app/google-services.json
+
       - name: Make Android APK Build Asset
         run: |
           (cd app && flutter build apk --release)


### PR DESCRIPTION


<!-- 
  PR Title must follow Semantic Commit format:
  <type>: <description>

  Types: feat, fix, docs, refactor, test, ci, chore, revert
  Examples:
    feat: add extra end scoring support
    fix: correct hammer tracking after blank end
    docs: update setup instructions
-->

## Summary

The google-services.json file is gitignored but required by the Google Services Gradle plugin during the Android release build. Without it, processReleaseGoogleServices fails with a 403-style missing file error.

https://claude.ai/code/session_01TrbENUXxMzHX5vju5oQYy7

## Test Plan

Run the version_increment workflow
