### PR TITLE
fix: resolve Android build failures in version increment workflow

### DIFF
--- a/.github/workflows/version_increment.yaml
+++ b/.github/workflows/version_increment.yaml
@@ -110,6 +110,9 @@ jobs:
           java-version: 17
           distribution: "temurin"
 
+      - name: Setup Google Services for Android
+        run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > app/android/app/google-services.json
+
       - name: Make Android APK Build Asset
         run: |
           (cd app && flutter build apk --release)

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -13,8 +13,8 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     defaultConfig {


### PR DESCRIPTION
## Summary

- Inject `google-services.json` from a GitHub secret before Android build steps — the file is gitignored but required by the Google Services Gradle plugin
- Align Java and Kotlin JVM targets to 17 in `app/android/app/build.gradle` — `compileOptions` was targeting `VERSION_1_8` while `kotlin.compilerOptions.jvmTarget` was set to `JVM_17`, causing a hard Gradle error

## Test plan

- [ ] Add `GOOGLE_SERVICES_JSON` secret to the repository (Settings → Secrets and variables → Actions) with the contents of your `google-services.json`
- [ ] Trigger the Version Increment workflow and confirm the APK and AAB build steps succeed

https://claude.ai/code/session_01TrbENUXxMzHX5vju5oQYy7

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrbENUXxMzHX5vju5oQYy7)_