### PR TITLE
ci: add target app to web deployment workflows

### DIFF
--- a/.github/workflows/deploy_web_dev.yaml
+++ b/.github/workflows/deploy_web_dev.yaml
@@ -28,6 +28,7 @@ jobs:
           expires: 30d
           channelId: live
           entryPoint: .
+          target: app
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:

--- a/.github/workflows/deploy_web_prod.yaml
+++ b/.github/workflows/deploy_web_prod.yaml
@@ -32,6 +32,7 @@ jobs:
           expires: 30d
           channelId: live
           entryPoint: .
+          target: app
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:


### PR DESCRIPTION
## Summary

Added the `target: app` configuration parameter to the Firebase deployment steps in both the development and production web deployment workflows. This explicitly specifies the deployment target for the Firebase CLI, ensuring the web app is deployed to the correct Firebase project target.

## Test Plan

CI workflows will validate the syntax and execution of the updated deployment configurations. The Firebase deployment steps will execute with the new target parameter during the next scheduled deployments.

https://claude.ai/code/session_01TYHHnA489vjeLUrPVCukw4