### PR TITLE
feat: restrict sheet creation for club admins

### DIFF
--- a/admin/src/pages/ClubAdminDashboard.tsx
+++ b/admin/src/pages/ClubAdminDashboard.tsx
@@ -27,5 +27,5 @@ export function ClubAdminDashboard({ user }: Props) {
   if (!club) return <p className={styles.error}>Club not found. Contact your administrator.</p>;
 
   // Pass club directly so ClubDetail doesn't need to re-fetch it
-  return <ClubDetail club={club} />;
+  return <ClubDetail club={club} isClubAdmin />;
 }

--- a/admin/src/pages/ClubDetail.tsx
+++ b/admin/src/pages/ClubDetail.tsx
@@ -21,9 +21,10 @@ function generateApiKey(): string {
 interface Props {
   // Optional: club admin dashboard passes the club directly to avoid an extra fetch
   club?: Club;
+  isClubAdmin?: boolean;
 }
 
-export function ClubDetail({ club: clubProp }: Props) {
+export function ClubDetail({ club: clubProp, isClubAdmin = false }: Props) {
   const { clubId } = useParams<{ clubId: string }>();
   const navigate = useNavigate();
 
@@ -124,9 +125,11 @@ export function ClubDetail({ club: clubProp }: Props) {
       <div className={styles.section}>
         <div className={styles.sectionHeader}>
           <h2 className={styles.sectionTitle}>Sheets ({sheets.length})</h2>
-          <button className={styles.primaryButton} onClick={() => setAddingSheet(true)}>
-            + Add Sheet
-          </button>
+          {!isClubAdmin && (
+            <button className={styles.primaryButton} onClick={() => setAddingSheet(true)}>
+              + Add Sheet
+            </button>
+          )}
         </div>
 
         {addingSheet && (


### PR DESCRIPTION
## Summary

Add an `isClubAdmin` prop to the `ClubDetail` component to conditionally hide the "Add Sheet" button when viewing the club detail page from the club admin dashboard. This prevents club admins from creating new sheets while still allowing them to view and manage existing club information.

The `ClubAdminDashboard` now passes `isClubAdmin={true}` when rendering `ClubDetail`, and the sheet creation button is only displayed when this flag is false.

## Test Plan

Verify that:
- The "Add Sheet" button is hidden when accessing `ClubDetail` from `ClubAdminDashboard`
- The "Add Sheet" button remains visible in other contexts where `isClubAdmin` is not set or is false
- Existing sheet management functionality is unaffected

https://claude.ai/code/session_01LSawKUWWV8MVCJ6chMXpAi