### PR TITLE
feat: add recent games section to club detail page

### DIFF
--- a/admin/src/pages/ClubDetail.module.css
+++ b/admin/src/pages/ClubDetail.module.css
@@ -248,3 +248,148 @@
   padding: 1rem 0;
   font-size: 0.9rem;
 }
+
+.gameCount {
+  font-size: 0.85rem;
+  color: #888;
+  font-weight: 400;
+}
+
+.dayGroup {
+  margin-bottom: 1.25rem;
+}
+
+.dayGroup:last-child {
+  margin-bottom: 0;
+}
+
+.dayLabel {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #888;
+  margin-bottom: 0.5rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.gameList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.gameCard {
+  background: #fafafa;
+  border: 1px solid #efefef;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.gameHeader {
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  text-align: left;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.gameHeader:hover {
+  background: #f2f2f2;
+}
+
+.gameScore {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.95rem;
+}
+
+.winnerName {
+  font-weight: 700;
+  color: #137333;
+}
+
+.loserName {
+  color: #666;
+}
+
+.scoreDisplay {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #1a1a2e;
+}
+
+.gameMeta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.82rem;
+  color: #888;
+  flex-wrap: wrap;
+}
+
+.sheetChip {
+  background: #e8f0fe;
+  color: #1967d2;
+  border-radius: 4px;
+  padding: 0.1rem 0.45rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.expandIcon {
+  font-size: 0.65rem;
+  color: #aaa;
+}
+
+.endsTable {
+  border-top: 1px solid #efefef;
+  overflow-x: auto;
+  padding: 0.75rem 1rem 0.9rem;
+}
+
+.endsTable table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.endsTable th,
+.endsTable td {
+  text-align: center;
+  padding: 0.3rem 0.4rem;
+  min-width: 1.8rem;
+}
+
+.endsTable th {
+  font-size: 0.72rem;
+  color: #999;
+  font-weight: 600;
+  border-bottom: 1px solid #efefef;
+}
+
+.teamLabel {
+  text-align: left !important;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.scoringEnd {
+  background: #e6f4ea;
+  font-weight: 700;
+  color: #137333;
+  border-radius: 4px;
+}
+
+.totalCell {
+  font-weight: 700;
+  border-left: 1px solid #efefef;
+}

--- a/admin/src/pages/ClubDetail.tsx
+++ b/admin/src/pages/ClubDetail.tsx
@@ -1,11 +1,35 @@
 import { useState, useEffect } from 'react';
 import {
   collection, doc, onSnapshot, updateDoc, deleteField, addDoc,
+  getDocs, query, where, orderBy, Timestamp,
 } from 'firebase/firestore';
 import { useParams, useNavigate } from 'react-router-dom';
 import { db } from '../lib/firebase';
-import type { Club, Sheet } from '../types';
+import type { Club, Sheet, Game } from '../types';
 import styles from './ClubDetail.module.css';
+
+interface RecentGame extends Game {
+  sheetId: string;
+  sheetName: string;
+}
+
+function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+function groupByDay(games: RecentGame[]): { label: string; games: RecentGame[] }[] {
+  const map = new Map<string, RecentGame[]>();
+  for (const game of games) {
+    const key = game.startedAt.toLocaleDateString(undefined, {
+      weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+    });
+    if (!map.has(key)) map.set(key, []);
+    map.get(key)!.push(game);
+  }
+  return Array.from(map.entries()).map(([label, games]) => ({ label, games }));
+}
 
 function generatePairingCode(): string {
   const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // cspell:ignore ABCDEFGHJKLMNPQRSTUVWXYZ
@@ -34,6 +58,12 @@ export function ClubDetail({ club: clubProp, isClubAdmin = false }: Props) {
   const [addingSheet, setAddingSheet] = useState(false);
   const [savingSheet, setSavingSheet] = useState(false);
 
+  // Stable sheet metadata (id + name only) — insulated from liveGame updates
+  const [sheetMeta, setSheetMeta] = useState<{ id: string; name: string }[]>([]);
+  const [recentGames, setRecentGames] = useState<RecentGame[]>([]);
+  const [recentGamesLoading, setRecentGamesLoading] = useState(false);
+  const [expandedGameId, setExpandedGameId] = useState<string | null>(null);
+
   const resolvedClubId = clubProp?.id ?? clubId!;
 
   // Only fetch club doc when we don't have it passed in (super admin navigating by URL)
@@ -53,6 +83,51 @@ export function ClubDetail({ club: clubProp, isClubAdmin = false }: Props) {
       );
     });
   }, [resolvedClubId]);
+
+  // Keep sheetMeta stable — only update when sheet ids or names change (not liveGame)
+  useEffect(() => {
+    const next = sheets.map(s => ({ id: s.id, name: s.name }));
+    setSheetMeta(prev => {
+      const prevKey = prev.map(s => s.id + s.name).join('|');
+      const nextKey = next.map(s => s.id + s.name).join('|');
+      return prevKey === nextKey ? prev : next;
+    });
+  }, [sheets]);
+
+  // Fetch recent games across all sheets for the past 7 days
+  useEffect(() => {
+    if (!sheetMeta.length) return;
+    let cancelled = false;
+    setRecentGamesLoading(true);
+    const sevenDaysAgo = Timestamp.fromDate(new Date(Date.now() - 7 * 24 * 60 * 60 * 1000));
+    Promise.all(
+      sheetMeta.map(sheet =>
+        getDocs(query(
+          collection(db, 'clubs', resolvedClubId, 'sheets', sheet.id, 'games'),
+          where('startedAt', '>=', sevenDaysAgo),
+          orderBy('startedAt', 'desc'),
+        )).then(snap =>
+          snap.docs.map(d => {
+            const data = d.data();
+            return {
+              id: d.id,
+              ...data,
+              sheetId: sheet.id,
+              sheetName: sheet.name,
+              startedAt: data.startedAt?.toDate?.() ?? new Date(),
+              finishedAt: data.finishedAt?.toDate?.() ?? new Date(),
+            } as RecentGame;
+          })
+        )
+      )
+    ).then(results => {
+      if (cancelled) return;
+      const all = results.flat().sort((a, b) => b.startedAt.getTime() - a.startedAt.getTime());
+      setRecentGames(all);
+      setRecentGamesLoading(false);
+    });
+    return () => { cancelled = true; };
+  }, [resolvedClubId, sheetMeta]);
 
   async function handleGeneratePairingCode(sheetId: string) {
     const code = generatePairingCode();
@@ -110,6 +185,92 @@ export function ClubDetail({ club: clubProp, isClubAdmin = false }: Props) {
           <h1 className={styles.title}>{club.name}</h1>
           <p className={styles.clubId}>ID: {club.id}</p>
         </div>
+      </div>
+
+      <div className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>Recent Games — Last 7 Days</h2>
+          <span className={styles.gameCount}>
+            {recentGamesLoading ? '…' : `${recentGames.length} game${recentGames.length !== 1 ? 's' : ''}`}
+          </span>
+        </div>
+
+        {recentGamesLoading && <p className={styles.empty}>Loading…</p>}
+
+        {!recentGamesLoading && recentGames.length === 0 && (
+          <p className={styles.empty}>No completed games in the last 7 days.</p>
+        )}
+
+        {!recentGamesLoading && groupByDay(recentGames).map(({ label, games }) => (
+          <div key={label} className={styles.dayGroup}>
+            <h3 className={styles.dayLabel}>{label}</h3>
+            <div className={styles.gameList}>
+              {games.map(game => (
+                <div key={`${game.sheetId}-${game.id}`} className={styles.gameCard}>
+                  <button
+                    className={styles.gameHeader}
+                    onClick={() => setExpandedGameId(expandedGameId === game.id ? null : game.id)}
+                  >
+                    <div className={styles.gameScore}>
+                      <span className={game.team1.totalScore >= game.team2.totalScore ? styles.winnerName : styles.loserName}>
+                        {game.team1.name}
+                      </span>
+                      <span className={styles.scoreDisplay}>
+                        {game.team1.totalScore} – {game.team2.totalScore}
+                      </span>
+                      <span className={game.team2.totalScore >= game.team1.totalScore ? styles.winnerName : styles.loserName}>
+                        {game.team2.name}
+                      </span>
+                    </div>
+                    <div className={styles.gameMeta}>
+                      <span className={styles.sheetChip}>{game.sheetName}</span>
+                      <span>{game.startedAt.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}</span>
+                      {game.ends.length > 0 && (
+                        <span>{formatDuration(game.ends[game.ends.length - 1].gameTimeInSeconds)}</span>
+                      )}
+                      <span>{game.numberOfEnds} ends</span>
+                      <span className={styles.expandIcon}>{expandedGameId === game.id ? '▲' : '▼'}</span>
+                    </div>
+                  </button>
+
+                  {expandedGameId === game.id && (
+                    <div className={styles.endsTable}>
+                      <table>
+                        <thead>
+                          <tr>
+                            <th>End</th>
+                            {game.ends.map(e => <th key={e.endNumber}>{e.endNumber}</th>)}
+                            <th>Total</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td className={styles.teamLabel}>{game.team1.name}</td>
+                            {game.ends.map(e => (
+                              <td key={e.endNumber} className={e.scoringTeam === game.team1.name ? styles.scoringEnd : ''}>
+                                {e.scoringTeam === game.team1.name ? e.score : e.scoringTeam === null ? '—' : '0'}
+                              </td>
+                            ))}
+                            <td className={styles.totalCell}>{game.team1.totalScore}</td>
+                          </tr>
+                          <tr>
+                            <td className={styles.teamLabel}>{game.team2.name}</td>
+                            {game.ends.map(e => (
+                              <td key={e.endNumber} className={e.scoringTeam === game.team2.name ? styles.scoringEnd : ''}>
+                                {e.scoringTeam === game.team2.name ? e.score : e.scoringTeam === null ? '—' : '0'}
+                              </td>
+                            ))}
+                            <td className={styles.totalCell}>{game.team2.totalScore}</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
       </div>
 
       <div className={styles.section}>

--- a/admin/tsconfig.tsbuildinfo
+++ b/admin/tsconfig.tsbuildinfo
@@ -1,0 +1,1 @@
+{"root":["./src/App.tsx","./src/main.tsx","./src/vite-env.d.ts","./src/components/Layout.tsx","./src/hooks/useAuth.ts","./src/lib/firebase.ts","./src/pages/ClubAdminDashboard.tsx","./src/pages/ClubDetail.tsx","./src/pages/GameHistory.tsx","./src/pages/LoginPage.tsx","./src/pages/SuperAdminDashboard.tsx","./src/types/index.ts"],"version":"6.0.3"}


### PR DESCRIPTION
## Summary

Added a "Recent Games — Last 7 Days" section to the ClubDetail page that displays completed games across all sheets in a club. Games are grouped by day and presented in collapsible cards showing:

- Team names and final scores (with visual distinction for winners)
- Sheet name, start time, game duration, and number of ends
- Expandable detailed scoring table showing end-by-end results for each team

### Changes

**ClubDetail.tsx:**
- Added `Game` type import and new `RecentGame` interface extending it with sheet metadata
- Implemented `formatDuration()` utility to display game duration in human-readable format (e.g., "1h 23m")
- Implemented `groupByDay()` utility to organize games by date for display
- Added state management for sheet metadata, recent games, loading state, and expanded game details
- Added effect hook to fetch games from the past 7 days across all sheets, with proper Firestore timestamp conversion
- Added UI section rendering games grouped by day with collapsible detail cards and scoring tables

**ClubDetail.module.css:**
- Added comprehensive styling for the new games section including:
  - Day group headers with uppercase labels and borders
  - Game cards with hover effects
  - Score display with color-coded winner/loser names
  - Metadata chips (sheet name, time, duration, end count)
  - Expandable scoring table with end-by-end breakdown
  - Responsive layout with proper spacing and typography

## Test Plan

Verify the Recent Games section displays correctly:
1. Navigate to a club detail page with completed games from the past 7 days
2. Confirm games are grouped by date with proper formatting
3. Click a game card to expand and verify the scoring table displays correctly
4. Confirm winner names are highlighted in green and loser names in gray
5. Verify the game count badge updates as games load
6. Test with a club that has no recent games to confirm empty state message

https://claude.ai/code/session_012Wcsf14PSA29h8BBsxk6kU