### PR TITLE
feat: add admin user creation functionality to club management

### DIFF
--- a/admin/src/pages/ClubDetail.module.css
+++ b/admin/src/pages/ClubDetail.module.css
@@ -393,3 +393,66 @@
   font-weight: 700;
   border-left: 1px solid #efefef;
 }
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.modalCard {
+  background: white;
+  border-radius: 12px;
+  padding: 2rem;
+  width: 100%;
+  max-width: 480px;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.2);
+}
+
+.modalTitle {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-bottom: 1.5rem;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #444;
+}
+
+.modalActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.error {
+  font-size: 0.85rem;
+  color: #d93025;
+  background: #fce8e6;
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+}
+
+.success {
+  font-size: 0.85rem;
+  color: #137333;
+  background: #e6f4ea;
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+}

--- a/admin/src/pages/ClubDetail.tsx
+++ b/admin/src/pages/ClubDetail.tsx
@@ -3,8 +3,9 @@ import {
   collection, doc, onSnapshot, updateDoc, deleteField, addDoc,
   getDocs, query, where, orderBy, Timestamp,
 } from 'firebase/firestore';
+import { httpsCallable } from 'firebase/functions';
 import { useParams, useNavigate } from 'react-router-dom';
-import { db } from '../lib/firebase';
+import { db, functions } from '../lib/firebase';
 import type { Club, Sheet, Game } from '../types';
 import styles from './ClubDetail.module.css';
 
@@ -57,6 +58,13 @@ export function ClubDetail({ club: clubProp, isClubAdmin = false }: Props) {
   const [newSheetName, setNewSheetName] = useState('');
   const [addingSheet, setAddingSheet] = useState(false);
   const [savingSheet, setSavingSheet] = useState(false);
+
+  const [showAddAdmin, setShowAddAdmin] = useState(false);
+  const [adminEmail, setAdminEmail] = useState('');
+  const [adminPassword, setAdminPassword] = useState('');
+  const [addingAdmin, setAddingAdmin] = useState(false);
+  const [addAdminError, setAddAdminError] = useState('');
+  const [addAdminSuccess, setAddAdminSuccess] = useState('');
 
   // Stable sheet metadata (id + name only) — insulated from liveGame updates
   const [sheetMeta, setSheetMeta] = useState<{ id: string; name: string }[]>([]);
@@ -165,6 +173,24 @@ export function ClubDetail({ club: clubProp, isClubAdmin = false }: Props) {
       navigate(`/sheets/${sheetId}/games`);
     } else {
       navigate(`/clubs/${resolvedClubId}/sheets/${sheetId}/games`);
+    }
+  }
+
+  async function handleAddAdmin(e: React.FormEvent) {
+    e.preventDefault();
+    setAddingAdmin(true);
+    setAddAdminError('');
+    setAddAdminSuccess('');
+    try {
+      const addClubAdmin = httpsCallable(functions, 'addClubAdmin');
+      await addClubAdmin({ clubId: resolvedClubId, adminEmail, adminPassword });
+      setAddAdminSuccess(`Admin account created for ${adminEmail}.`);
+      setAdminEmail('');
+      setAdminPassword('');
+    } catch (err) {
+      setAddAdminError(err instanceof Error ? err.message : 'Failed to add admin.');
+    } finally {
+      setAddingAdmin(false);
     }
   }
 
@@ -282,6 +308,58 @@ export function ClubDetail({ club: clubProp, isClubAdmin = false }: Props) {
           </button>
         </div>
       </div>
+
+      {!isClubAdmin && (
+        <div className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <h2 className={styles.sectionTitle}>Admins</h2>
+            <button className={styles.primaryButton} onClick={() => { setShowAddAdmin(true); setAddAdminError(''); setAddAdminSuccess(''); }}>
+              + Add Admin
+            </button>
+          </div>
+
+          {showAddAdmin && (
+            <div className={styles.modal}>
+              <div className={styles.modalCard}>
+                <h2 className={styles.modalTitle}>Add Admin to {club.name}</h2>
+                <form onSubmit={handleAddAdmin} className={styles.form}>
+                  <label className={styles.label}>
+                    Admin Email
+                    <input
+                      type="email"
+                      className={styles.input}
+                      value={adminEmail}
+                      onChange={(e) => setAdminEmail(e.target.value)}
+                      required
+                    />
+                  </label>
+                  <label className={styles.label}>
+                    Password
+                    <input
+                      type="password"
+                      className={styles.input}
+                      value={adminPassword}
+                      onChange={(e) => setAdminPassword(e.target.value)}
+                      required
+                      minLength={8}
+                    />
+                  </label>
+                  {addAdminError && <p className={styles.error}>{addAdminError}</p>}
+                  {addAdminSuccess && <p className={styles.success}>{addAdminSuccess}</p>}
+                  <div className={styles.modalActions}>
+                    <button type="button" className={styles.ghostButton} onClick={() => setShowAddAdmin(false)}>
+                      Close
+                    </button>
+                    <button type="submit" className={styles.primaryButton} disabled={addingAdmin}>
+                      {addingAdmin ? 'Adding…' : 'Add Admin'}
+                    </button>
+                  </div>
+                </form>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
 
       <div className={styles.section}>
         <div className={styles.sectionHeader}>

--- a/functions/src/admin.ts
+++ b/functions/src/admin.ts
@@ -53,6 +53,44 @@ export const provisionClub = onCall(async (request) => {
   return { clubId: clubRef.id, uid: userRecord.uid };
 });
 
+// Adds a new admin user to an existing club.
+export const addClubAdmin = onCall(async (request) => {
+  requireSuperAdmin(request.auth);
+
+  const { clubId, adminEmail, adminPassword } = request.data as {
+    clubId: string;
+    adminEmail: string;
+    adminPassword: string;
+  };
+
+  if (!clubId || !adminEmail || !adminPassword) {
+    throw new HttpsError('invalid-argument', 'clubId, adminEmail and adminPassword are required.');
+  }
+
+  const clubSnap = await admin.firestore().collection('clubs').doc(clubId).get();
+  if (!clubSnap.exists) {
+    throw new HttpsError('not-found', 'Club not found.');
+  }
+
+  let userRecord: admin.auth.UserRecord;
+  try {
+    userRecord = await admin.auth().createUser({
+      email: adminEmail,
+      password: adminPassword,
+      displayName: `${(clubSnap.data() as { name: string }).name} Admin`,
+    });
+  } catch (err) {
+    throw new HttpsError('already-exists', `Could not create user: ${(err as Error).message}`);
+  }
+
+  await admin.auth().setCustomUserClaims(userRecord.uid, {
+    role: 'clubadmin',
+    clubId,
+  });
+
+  return { uid: userRecord.uid };
+});
+
 // Sets a user as super admin. Call this once manually via Firebase SDK or Console
 // to bootstrap the first super admin account.
 export const setSuperAdminClaim = onCall(async (request) => {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3,7 +3,7 @@ import { onRequest } from 'firebase-functions/v2/https';
 import express from 'express';
 import cors from 'cors';
 import { clubsRouter } from './routes/clubs';
-export { provisionClub, setSuperAdminClaim } from './admin';
+export { provisionClub, setSuperAdminClaim, addClubAdmin } from './admin';
 
 admin.initializeApp();
 


### PR DESCRIPTION
## Summary

Adds the ability for super admins to create new admin accounts for existing clubs. This includes:

- New `addClubAdmin` Cloud Function that creates a Firebase Auth user with club admin role and custom claims
- UI modal in ClubDetail page for entering admin email and password
- Form validation and error/success messaging
- Integration with Firebase Functions callable API

The feature is only visible to super admins (when `isClubAdmin` is false) and allows provisioning additional club administrators without requiring manual Firebase Console access.

## Test Plan

- Verify the "Add Admin" button appears only for super admins in the club detail view
- Test the modal form submission with valid email and password
- Verify error handling for duplicate emails and invalid inputs
- Confirm the created user has the correct custom claims (`role: 'clubadmin'` and `clubId`)
- Test that the form clears and shows success message after successful creation

https://claude.ai/code/session_01MGV86PphJyLAdAtU8cm3BK