### PR TITLE
feat: add API documentation link to Club Detail page

### DIFF
--- a/admin/src/pages/ClubDetail.module.css
+++ b/admin/src/pages/ClubDetail.module.css
@@ -60,6 +60,21 @@
   margin-bottom: 0;
 }
 
+.apiDocsBlurb {
+  margin: 0 0 1rem;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.apiDocsBlurb a {
+  color: #1a73e8;
+  text-decoration: none;
+}
+
+.apiDocsBlurb a:hover {
+  text-decoration: underline;
+}
+
 .apiKeyRow {
   display: flex;
   align-items: center;

--- a/admin/src/pages/ClubDetail.tsx
+++ b/admin/src/pages/ClubDetail.tsx
@@ -301,6 +301,12 @@ export function ClubDetail({ club: clubProp, isClubAdmin = false }: Props) {
 
       <div className={styles.section}>
         <h2 className={styles.sectionTitle}>API Access</h2>
+        <p className={styles.apiDocsBlurb}>
+          Want to know how to use the API?{' '}
+          <a href="https://curlingscoreboard.app/api-docs/" target="_blank" rel="noopener noreferrer">
+            View the API documentation
+          </a>
+        </p>
         <div className={styles.apiKeyRow}>
           <code className={styles.apiKey}>{club.apiKey || '—'}</code>
           <button className={styles.ghostButton} onClick={handleRegenerateApiKey}>


### PR DESCRIPTION
## Summary

Added a helpful link to API documentation in the API Access section of the Club Detail page. This includes:

- New `.apiDocsBlurb` styles with appropriate spacing, font size, and link styling
- A paragraph with a link to the API documentation (https://curlingscoreboard.app/api-docs/) positioned above the API key display
- Link opens in a new tab with proper security attributes (`target="_blank" rel="noopener noreferrer"`)

This improves discoverability of API documentation for club administrators managing API access.

## Test Plan

Verify that the API documentation link appears in the API Access section of the Club Detail page, opens in a new tab when clicked, and displays with appropriate styling (smaller font, gray text, blue link color with underline on hover).

https://claude.ai/code/session_01D3oodKXYXTtBPNKybafaKq