### PR TITLE
feat: List club admins in super admin UI

### DIFF
--- a/admin/src/pages/ClubDetail.module.css
+++ b/admin/src/pages/ClubDetail.module.css
@@ -471,3 +471,31 @@
   border-radius: 6px;
   padding: 0.5rem 0.75rem;
 }
+
+.adminList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.adminRow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 0.85rem;
+  background: #fafafa;
+  border: 1px solid #efefef;
+  border-radius: 8px;
+}
+
+.adminName {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #1a1a2e;
+}
+
+.adminEmail {
+  font-size: 0.85rem;
+  color: #666;
+}

--- a/admin/src/pages/ClubDetail.tsx
+++ b/admin/src/pages/ClubDetail.tsx
@@ -59,6 +59,8 @@ export function ClubDetail({ club: clubProp, isClubAdmin = false }: Props) {
   const [addingSheet, setAddingSheet] = useState(false);
   const [savingSheet, setSavingSheet] = useState(false);
 
+  const [clubAdmins, setClubAdmins] = useState<{ uid: string; email: string; displayName: string | null }[]>([]);
+
   const [showAddAdmin, setShowAddAdmin] = useState(false);
   const [adminEmail, setAdminEmail] = useState('');
   const [adminPassword, setAdminPassword] = useState('');
@@ -91,6 +93,15 @@ export function ClubDetail({ club: clubProp, isClubAdmin = false }: Props) {
       );
     });
   }, [resolvedClubId]);
+
+  useEffect(() => {
+    if (isClubAdmin) return;
+    return onSnapshot(collection(db, 'clubs', resolvedClubId, 'admins'), (snap) => {
+      setClubAdmins(
+        snap.docs.map((d) => ({ uid: d.id, ...(d.data() as { email: string; displayName: string | null }) }))
+      );
+    });
+  }, [resolvedClubId, isClubAdmin]);
 
   // Keep sheetMeta stable — only update when sheet ids or names change (not liveGame)
   useEffect(() => {
@@ -318,10 +329,20 @@ export function ClubDetail({ club: clubProp, isClubAdmin = false }: Props) {
       {!isClubAdmin && (
         <div className={styles.section}>
           <div className={styles.sectionHeader}>
-            <h2 className={styles.sectionTitle}>Admins</h2>
+            <h2 className={styles.sectionTitle}>Admins ({clubAdmins.length})</h2>
             <button className={styles.primaryButton} onClick={() => { setShowAddAdmin(true); setAddAdminError(''); setAddAdminSuccess(''); }}>
               + Add Admin
             </button>
+          </div>
+
+          <div className={styles.adminList}>
+            {clubAdmins.map((a) => (
+              <div key={a.uid} className={styles.adminRow}>
+                {a.displayName && <span className={styles.adminName}>{a.displayName}</span>}
+                <span className={styles.adminEmail}>{a.email}</span>
+              </div>
+            ))}
+            {clubAdmins.length === 0 && <p className={styles.empty}>No admins yet.</p>}
           </div>
 
           {showAddAdmin && (

--- a/firestore.rules
+++ b/firestore.rules
@@ -27,6 +27,10 @@ service cloud.firestore {
       // Club admins can read their own club.
       allow read: if request.auth != null;
 
+      match /admins/{uid} {
+        allow read: if isClubAdmin(clubId);
+      }
+
       match /sheets/{sheetId} {
         // Club admins can read any sheet in their club.
         allow read: if isClubAdmin(clubId);

--- a/functions/src/admin.ts
+++ b/functions/src/admin.ts
@@ -50,6 +50,11 @@ export const provisionClub = onCall(async (request) => {
     clubId: clubRef.id,
   });
 
+  await clubRef.collection('admins').doc(userRecord.uid).set({
+    email: adminEmail,
+    displayName: userRecord.displayName ?? null,
+  });
+
   return { clubId: clubRef.id, uid: userRecord.uid };
 });
 
@@ -87,6 +92,11 @@ export const addClubAdmin = onCall(async (request) => {
     role: 'clubadmin',
     clubId,
   });
+
+  await admin.firestore()
+    .collection('clubs').doc(clubId)
+    .collection('admins').doc(userRecord.uid)
+    .set({ email: adminEmail, displayName: userRecord.displayName ?? null });
 
   return { uid: userRecord.uid };
 });


### PR DESCRIPTION
## Summary

- Stores admin records in `clubs/{clubId}/admins/{uid}` (email + displayName) when creating an admin via both `provisionClub` and `addClubAdmin`
- Subscribes to that subcollection in `ClubDetail` to display a live admin list with count in the section header
- Adds a Firestore rule so club admins can read their own club's `admins` subcollection

## Note

Clubs created before this change won't have records in the `admins` subcollection and will show "No admins yet" until a new admin is added or the existing records are backfilled.

## Test plan

- [ ] Create a new club — the provisioned admin should appear in the Admins list
- [ ] Use "+ Add Admin" to add a second admin — they should appear in the list immediately
- [ ] Confirm the list is not visible when logged in as a club admin

https://claude.ai/code/session_01MGV86PphJyLAdAtU8cm3BK

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGV86PphJyLAdAtU8cm3BK)_