### PR TITLE
feat: allow custom club IDs during provisioning

### DIFF
--- a/admin/src/pages/SuperAdminDashboard.tsx
+++ b/admin/src/pages/SuperAdminDashboard.tsx
@@ -6,11 +6,22 @@ import { db, functions } from '../lib/firebase';
 import type { Club } from '../types';
 import styles from './SuperAdminDashboard.module.css';
 
+function toSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+}
+
 export function SuperAdminDashboard() {
   const navigate = useNavigate();
   const [clubs, setClubs] = useState<Club[]>([]);
   const [showCreateClub, setShowCreateClub] = useState(false);
   const [newClubName, setNewClubName] = useState('');
+  const [clubId, setClubId] = useState('');
+  const [clubIdEdited, setClubIdEdited] = useState(false);
   const [adminEmail, setAdminEmail] = useState('');
   const [adminPassword, setAdminPassword] = useState('');
   const [creating, setCreating] = useState(false);
@@ -24,14 +35,28 @@ export function SuperAdminDashboard() {
     });
   }, []);
 
+  function handleClubNameChange(name: string) {
+    setNewClubName(name);
+    if (!clubIdEdited) {
+      setClubId(toSlug(name));
+    }
+  }
+
+  function handleClubIdChange(id: string) {
+    setClubId(id);
+    setClubIdEdited(id !== toSlug(newClubName));
+  }
+
   async function handleCreateClub(e: React.FormEvent) {
     e.preventDefault();
     setCreating(true);
     setCreateError('');
     try {
       const provisionClub = httpsCallable(functions, 'provisionClub');
-      await provisionClub({ clubName: newClubName, adminEmail, adminPassword });
+      await provisionClub({ clubName: newClubName, clubId: clubId || undefined, adminEmail, adminPassword });
       setNewClubName('');
+      setClubId('');
+      setClubIdEdited(false);
       setAdminEmail('');
       setAdminPassword('');
       setShowCreateClub(false);
@@ -64,7 +89,18 @@ export function SuperAdminDashboard() {
                 <input
                   className={styles.input}
                   value={newClubName}
-                  onChange={(e) => setNewClubName(e.target.value)}
+                  onChange={(e) => handleClubNameChange(e.target.value)}
+                  required
+                />
+              </label>
+              <label className={styles.label}>
+                Club ID
+                <input
+                  className={styles.input}
+                  value={clubId}
+                  onChange={(e) => handleClubIdChange(e.target.value)}
+                  pattern="[a-z0-9-]+"
+                  title="Lowercase letters, numbers, and hyphens only"
                   required
                 />
               </label>

--- a/functions/src/admin.ts
+++ b/functions/src/admin.ts
@@ -12,8 +12,9 @@ function requireSuperAdmin(auth: { token: admin.auth.DecodedIdToken } | undefine
 export const provisionClub = onCall(async (request) => {
   requireSuperAdmin(request.auth);
 
-  const { clubName, adminEmail, adminPassword } = request.data as {
+  const { clubName, clubId, adminEmail, adminPassword } = request.data as {
     clubName: string;
+    clubId?: string;
     adminEmail: string;
     adminPassword: string;
   };
@@ -24,11 +25,17 @@ export const provisionClub = onCall(async (request) => {
 
   const apiKey = crypto.randomBytes(16).toString('hex');
 
-  // Create club document with auto-generated ID
-  const clubRef = await admin.firestore().collection('clubs').add({
-    name: clubName,
-    apiKey,
-  });
+  let clubRef: admin.firestore.DocumentReference;
+  if (clubId) {
+    clubRef = admin.firestore().collection('clubs').doc(clubId);
+    const existing = await clubRef.get();
+    if (existing.exists) {
+      throw new HttpsError('already-exists', `A club with id "${clubId}" already exists.`);
+    }
+    await clubRef.set({ name: clubName, apiKey });
+  } else {
+    clubRef = await admin.firestore().collection('clubs').add({ name: clubName, apiKey });
+  }
 
   // Create the Firebase Auth user
   let userRecord: admin.auth.UserRecord;


### PR DESCRIPTION
## Summary

This change adds support for specifying custom club IDs when provisioning new clubs, while maintaining backward compatibility with auto-generated IDs.

**Frontend changes:**
- Added a `toSlug()` utility function to convert club names into URL-safe slugs
- Added a "Club ID" input field to the club creation form that auto-populates based on the club name
- Implemented smart tracking to detect when the user manually edits the club ID vs. when it's auto-generated
- Updated the `provisionClub` call to pass the optional `clubId` parameter

**Backend changes:**
- Modified the `provisionClub` Cloud Function to accept an optional `clubId` parameter
- When a custom `clubId` is provided, the function now creates a document with that specific ID instead of using Firestore's auto-generated ID
- Added validation to prevent duplicate club IDs with an `already-exists` error
- Maintains backward compatibility: if no `clubId` is provided, the function falls back to auto-generated IDs

## Test Plan

- Verify club creation works with auto-generated IDs (existing behavior)
- Verify club creation works with custom club IDs
- Verify the club ID input auto-populates when typing a club name
- Verify manual edits to the club ID prevent auto-population
- Verify attempting to create a club with a duplicate ID shows an appropriate error
- Verify the club ID input only accepts lowercase letters, numbers, and hyphens

https://claude.ai/code/session_01H95SVs7tjpL8KMpdGMdgRp