### PR TITLE
fix: add BuildContext.l10n extension for translations_cleaner 0.2.x compatibility

### DIFF
--- a/admin/src/pages/ClubDetail.tsx
+++ b/admin/src/pages/ClubDetail.tsx
@@ -68,6 +68,7 @@ export function ClubDetail({ club: clubProp, isClubAdmin = false }: Props) {
   const [addAdminError, setAddAdminError] = useState('');
   const [addAdminSuccess, setAddAdminSuccess] = useState('');
 
+
   // Stable sheet metadata (id + name only) — insulated from liveGame updates
   const [sheetMeta, setSheetMeta] = useState<{ id: string; name: string }[]>([]);
   const [recentGames, setRecentGames] = useState<RecentGame[]>([]);
@@ -102,6 +103,7 @@ export function ClubDetail({ club: clubProp, isClubAdmin = false }: Props) {
       );
     });
   }, [resolvedClubId, isClubAdmin]);
+
 
   // Keep sheetMeta stable — only update when sheet ids or names change (not liveGame)
   useEffect(() => {

--- a/app/lib/l10n/l10n.dart
+++ b/app/lib/l10n/l10n.dart
@@ -1,0 +1,8 @@
+import 'package:curling_scoreboard/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+
+export 'package:curling_scoreboard/l10n/app_localizations.dart';
+
+extension BuildContextL10n on BuildContext {
+  AppLocalizations get l10n => AppLocalizations.of(this)!;
+}

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:curling_scoreboard/constants.dart';
 import 'package:curling_scoreboard/firebase_options_dev.dart' as dev;
 import 'package:curling_scoreboard/firebase_options_prod.dart' as prod;
-import 'package:curling_scoreboard/l10n/app_localizations.dart';
+import 'package:curling_scoreboard/l10n/l10n.dart';
 import 'package:curling_scoreboard/models/models.dart';
 import 'package:curling_scoreboard/services/registration_service.dart';
 import 'package:curling_scoreboard/services/sync_service.dart';
@@ -290,7 +290,7 @@ class _CurlingScoreboardScreenState extends State<CurlingScoreboardScreen> {
         actions: <Widget>[
           AppBarActionButton(
             icon: Icons.add,
-            label: AppLocalizations.of(context)!.appBarAddScoreButtonLabel,
+            label: context.l10n.appBarAddScoreButtonLabel,
             onPressed: () async {
               if (gameObject.ends.length < gameObject.numberOfEnds + 1) {
                 await showEnterScoreDialog(context);
@@ -298,7 +298,7 @@ class _CurlingScoreboardScreenState extends State<CurlingScoreboardScreen> {
                 ScaffoldMessenger.of(context).showSnackBar(
                   SnackBar(
                     content: Text(
-                      AppLocalizations.of(context)!.addScoreGameCompleteMessage,
+                      context.l10n.addScoreGameCompleteMessage,
                     ),
                   ),
                 );
@@ -307,7 +307,7 @@ class _CurlingScoreboardScreenState extends State<CurlingScoreboardScreen> {
           ),
           AppBarActionButton(
             icon: Icons.sports_score,
-            label: AppLocalizations.of(context)!.appBarFinishGameButtonLabel,
+            label: context.l10n.appBarFinishGameButtonLabel,
             onPressed: () async {
               await showFinishGameConfirmationDialog(context);
             },
@@ -381,7 +381,7 @@ class _CurlingScoreboardScreenState extends State<CurlingScoreboardScreen> {
       builder: (context) {
         return StatefulBuilder(
           builder: (context, setStateDialog) {
-            final l10n = AppLocalizations.of(context)!;
+            final l10n = context.l10n;
             final reg = widget.registrationService;
 
             return AlertDialog(

--- a/app/lib/widgets/app_bar/finish_game_dialog.dart
+++ b/app/lib/widgets/app_bar/finish_game_dialog.dart
@@ -1,4 +1,4 @@
-import 'package:curling_scoreboard/l10n/app_localizations.dart';
+import 'package:curling_scoreboard/l10n/l10n.dart';
 import 'package:flutter/material.dart';
 
 class FinishGameDialog extends StatelessWidget {
@@ -10,7 +10,7 @@ class FinishGameDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return AlertDialog(
       content: Text(
-        AppLocalizations.of(context)!.finishGameConfirmationDialogDescription,
+        context.l10n.finishGameConfirmationDialogDescription,
         style: const TextStyle(fontSize: 40, fontWeight: FontWeight.bold),
       ),
       contentPadding: const EdgeInsets.all(50),
@@ -23,7 +23,7 @@ class FinishGameDialog extends StatelessWidget {
             finishGameAction(context);
           },
           child: Text(
-            AppLocalizations.of(context)!.buttonLabelYes,
+            context.l10n.buttonLabelYes,
             style: const TextStyle(fontSize: 40, fontWeight: FontWeight.bold),
           ),
         ),
@@ -32,7 +32,7 @@ class FinishGameDialog extends StatelessWidget {
             Navigator.of(context).pop();
           },
           child: Text(
-            AppLocalizations.of(context)!.buttonLabelNo,
+            context.l10n.buttonLabelNo,
             style: const TextStyle(fontSize: 40, fontWeight: FontWeight.bold),
           ),
         ),

--- a/app/lib/widgets/app_bar/score_input_dialog.dart
+++ b/app/lib/widgets/app_bar/score_input_dialog.dart
@@ -1,5 +1,5 @@
 import 'package:curling_scoreboard/constants.dart';
-import 'package:curling_scoreboard/l10n/app_localizations.dart';
+import 'package:curling_scoreboard/l10n/l10n.dart';
 import 'package:curling_scoreboard/models/models.dart';
 import 'package:flutter/material.dart';
 import 'package:material_segmented_control/material_segmented_control.dart';
@@ -23,7 +23,7 @@ class ScoreInputDialog extends StatelessWidget {
 
     if (defaultTeam != null) {
       currentTeamSelectedIndex =
-          defaultTeam == AppLocalizations.of(context)!.teamNameRed ? 0 : 1;
+          defaultTeam == context.l10n.teamNameRed ? 0 : 1;
     }
 
     var selectedScore = defaultScore;
@@ -33,11 +33,11 @@ class ScoreInputDialog extends StatelessWidget {
       0: Padding(
         padding: const EdgeInsets.fromLTRB(50, 0, 50, 0),
         child: EnterEditScoreDialogTeamText(
-          team: AppLocalizations.of(context)!.teamNameRed,
+          team: context.l10n.teamNameRed,
         ),
       ),
       1: EnterEditScoreDialogTeamText(
-        team: AppLocalizations.of(context)!.teamNameYellow,
+        team: context.l10n.teamNameYellow,
       ),
     };
 
@@ -60,7 +60,7 @@ class ScoreInputDialog extends StatelessWidget {
       builder: (context, setState) {
         return AlertDialog(
           title: Text(
-            AppLocalizations.of(context)!.scoreInputDialogTitle(end.toString()),
+            context.l10n.scoreInputDialogTitle(end.toString()),
           ),
           content: Column(
             mainAxisSize: MainAxisSize.min,
@@ -112,12 +112,8 @@ class ScoreInputDialog extends StatelessWidget {
                         currentTeamSelectedIndex = index;
 
                         index == 0
-                            ? selectedTeam = AppLocalizations.of(
-                                context,
-                              )!.teamNameRed
-                            : selectedTeam = AppLocalizations.of(
-                                context,
-                              )!.teamNameYellow;
+                            ? selectedTeam = context.l10n.teamNameRed
+                            : selectedTeam = context.l10n.teamNameYellow;
                       });
                     },
                   ),
@@ -139,7 +135,7 @@ class ScoreInputDialog extends StatelessWidget {
                       Navigator.pop(context, newEnd);
                     },
               child: Text(
-                AppLocalizations.of(context)!.scoreInputEnterButtonLabel,
+                context.l10n.scoreInputEnterButtonLabel,
                 style: const TextStyle(
                   fontSize: 40,
                   fontWeight: FontWeight.bold,

--- a/app/lib/widgets/app_bar/score_input_dialog.dart
+++ b/app/lib/widgets/app_bar/score_input_dialog.dart
@@ -22,8 +22,9 @@ class ScoreInputDialog extends StatelessWidget {
     int? currentTeamSelectedIndex;
 
     if (defaultTeam != null) {
-      currentTeamSelectedIndex =
-          defaultTeam == context.l10n.teamNameRed ? 0 : 1;
+      currentTeamSelectedIndex = defaultTeam == context.l10n.teamNameRed
+          ? 0
+          : 1;
     }
 
     var selectedScore = defaultScore;

--- a/app/lib/widgets/game_end/game_end_dialog.dart
+++ b/app/lib/widgets/game_end/game_end_dialog.dart
@@ -1,4 +1,4 @@
-import 'package:curling_scoreboard/l10n/app_localizations.dart';
+import 'package:curling_scoreboard/l10n/l10n.dart';
 import 'package:curling_scoreboard/models/models.dart';
 import 'package:flutter/material.dart';
 
@@ -12,7 +12,7 @@ class GameEndDialog extends StatelessWidget {
     return StatefulBuilder(
       builder: (context, setState) {
         return AlertDialog(
-          title: Text(AppLocalizations.of(context)!.gameEndDialogTitle),
+          title: Text(context.l10n.gameEndDialogTitle),
           content: GameSummaryWidget(
             team1Name: gameObject.team1.name,
             team2Name: gameObject.team2.name,
@@ -28,7 +28,7 @@ class GameEndDialog extends StatelessWidget {
                 Navigator.pop(context);
               },
               child: Text(
-                AppLocalizations.of(context)!.gameEndDialogButtonLabelDismiss,
+                context.l10n.gameEndDialogButtonLabelDismiss,
                 style: const TextStyle(
                   fontSize: 40,
                   fontWeight: FontWeight.bold,
@@ -80,19 +80,15 @@ class GameSummaryWidget extends StatelessWidget {
         TableRow(
           children: <Widget>[
             GameEndTableHeaderText(
-              text: AppLocalizations.of(context)!.gameEndDialogEndTableHeader,
+              text: context.l10n.gameEndDialogEndTableHeader,
             ),
             GameEndTableHeaderText(text: team1Name, color: team1Color),
             GameEndTableHeaderText(text: team2Name, color: team2Color),
             GameEndTableHeaderText(
-              text: AppLocalizations.of(
-                context,
-              )!.gameEndDialogEndTimeTableHeader,
+              text: context.l10n.gameEndDialogEndTimeTableHeader,
             ),
             GameEndTableHeaderText(
-              text: AppLocalizations.of(
-                context,
-              )!.gameEndDialogGameTimeTableHeader,
+              text: context.l10n.gameEndDialogGameTimeTableHeader,
             ),
           ],
         ),
@@ -133,9 +129,7 @@ class GameSummaryWidget extends StatelessWidget {
         TableRow(
           children: <Widget>[
             GameEndTableCellText(
-              text: AppLocalizations.of(
-                context,
-              )!.gameEndDialogTotalsTableHeader,
+              text: context.l10n.gameEndDialogTotalsTableHeader,
             ),
             GameEndTableCellText(
               text: team1TotalScore.toString(),

--- a/app/lib/widgets/game_info/game_info_row_widget.dart
+++ b/app/lib/widgets/game_info/game_info_row_widget.dart
@@ -1,4 +1,4 @@
-import 'package:curling_scoreboard/l10n/app_localizations.dart';
+import 'package:curling_scoreboard/l10n/l10n.dart';
 import 'package:flutter/material.dart';
 
 class GameInfoRowWidget extends StatelessWidget {
@@ -19,9 +19,7 @@ class GameInfoRowWidget extends StatelessWidget {
         Expanded(
           child: FittedBox(
             child: Text(
-              AppLocalizations.of(
-                context,
-              )!.gameInfoGameTimeLabel(_printDuration(gameTime)),
+              context.l10n.gameInfoGameTimeLabel(_printDuration(gameTime)),
             ),
           ),
         ),

--- a/app/lib/widgets/game_start/game_start_dialog.dart
+++ b/app/lib/widgets/game_start/game_start_dialog.dart
@@ -1,5 +1,5 @@
 import 'package:curling_scoreboard/constants.dart';
-import 'package:curling_scoreboard/l10n/app_localizations.dart';
+import 'package:curling_scoreboard/l10n/l10n.dart';
 import 'package:curling_scoreboard/models/models.dart';
 import 'package:curling_scoreboard/src/version.dart';
 import 'package:flutter/material.dart';
@@ -33,11 +33,11 @@ class GameStartDialog extends StatelessWidget {
       0: Padding(
         padding: const EdgeInsets.fromLTRB(50, 0, 50, 0),
         child: GameStartSegmentControlText(
-          text: AppLocalizations.of(context)!.teamNameRed,
+          text: context.l10n.teamNameRed,
         ),
       ),
       1: GameStartSegmentControlText(
-        text: AppLocalizations.of(context)!.teamNameYellow,
+        text: context.l10n.teamNameYellow,
       ),
     };
 
@@ -51,15 +51,13 @@ class GameStartDialog extends StatelessWidget {
         final numberOfPlayersPerTeam = {
           0: GameStartSegmentControlText(
             text: '0',
-            subtext: AppLocalizations.of(
-              context,
-            )!.gameStartDialogZeroPlayersButtonLabel,
+            subtext: context.l10n.gameStartDialogZeroPlayersButtonLabel,
           ),
           2: Padding(
             padding: const EdgeInsets.fromLTRB(50, 0, 50, 0),
             child: GameStartSegmentControlText(
               text: '2',
-              subtext: AppLocalizations.of(context)!
+              subtext: context.l10n
                   .gameStartDialogTimePerEndByPlayersButtonLabel(
                     Constants.minutesPerEndTwoPlayers.toString(),
                     _printDuration(
@@ -74,8 +72,7 @@ class GameStartDialog extends StatelessWidget {
           ),
           4: GameStartSegmentControlText(
             text: '4',
-            subtext: AppLocalizations.of(context)!
-                .gameStartDialogTimePerEndByPlayersButtonLabel(
+            subtext: context.l10n.gameStartDialogTimePerEndByPlayersButtonLabel(
                   Constants.minutesPerEndFourPlayers.toString(),
                   _printDuration(
                     Duration(
@@ -89,7 +86,7 @@ class GameStartDialog extends StatelessWidget {
         };
 
         return AlertDialog(
-          title: Text(AppLocalizations.of(context)!.gameStartDialogTitle),
+          title: Text(context.l10n.gameStartDialogTitle),
           content: Form(
             child: Column(
               mainAxisSize: MainAxisSize.min,
@@ -97,9 +94,7 @@ class GameStartDialog extends StatelessWidget {
                 Row(
                   children: [
                     Text(
-                      AppLocalizations.of(
-                        context,
-                      )!.gameStartDialogFormLabelNumberOfEnds,
+                      context.l10n.gameStartDialogFormLabelNumberOfEnds,
                       style: const TextStyle(fontSize: 40),
                     ),
                     MaterialSegmentedControl(
@@ -126,9 +121,7 @@ class GameStartDialog extends StatelessWidget {
                 Row(
                   children: [
                     Text(
-                      AppLocalizations.of(
-                        context,
-                      )!.gameStartDialogFormLabelPlayersPerTeam,
+                      context.l10n.gameStartDialogFormLabelPlayersPerTeam,
                       style: const TextStyle(fontSize: 40),
                     ),
                     MaterialSegmentedControl(
@@ -156,9 +149,7 @@ class GameStartDialog extends StatelessWidget {
                 Row(
                   children: [
                     Text(
-                      AppLocalizations.of(
-                        context,
-                      )!.gameStartDialogFormLabelFirstEndHammer,
+                      context.l10n.gameStartDialogFormLabelFirstEndHammer,
                       style: const TextStyle(fontSize: 40),
                     ),
                     MaterialSegmentedControl(
@@ -197,14 +188,14 @@ class GameStartDialog extends StatelessWidget {
             ElevatedButton(
               onPressed: () {
                 final team1 = CurlingTeam(
-                  name: AppLocalizations.of(context)!.teamNameRed,
+                  name: context.l10n.teamNameRed,
                   color: Constants.redTeamColor,
                   textColor: Constants.textHighContrastColor,
                   hasHammer: settingsHammerTeam == 0,
                   hadLastStoneFirstEnd: settingsHammerTeam == 0,
                 );
                 final team2 = CurlingTeam(
-                  name: AppLocalizations.of(context)!.teamNameYellow,
+                  name: context.l10n.teamNameYellow,
                   color: Constants.yellowTeamColor,
                   textColor: Constants.textDefaultColor,
                   hasHammer: settingsHammerTeam == 1,
@@ -221,9 +212,7 @@ class GameStartDialog extends StatelessWidget {
                 Navigator.pop(context, newCurlingGame);
               },
               child: Text(
-                AppLocalizations.of(
-                  context,
-                )!.gameStartDialogButtonLabelStartGame,
+                context.l10n.gameStartDialogButtonLabelStartGame,
                 style: const TextStyle(
                   fontSize: 40,
                   fontWeight: FontWeight.bold,

--- a/app/lib/widgets/game_start/game_start_dialog.dart
+++ b/app/lib/widgets/game_start/game_start_dialog.dart
@@ -73,15 +73,14 @@ class GameStartDialog extends StatelessWidget {
           4: GameStartSegmentControlText(
             text: '4',
             subtext: context.l10n.gameStartDialogTimePerEndByPlayersButtonLabel(
-                  Constants.minutesPerEndFourPlayers.toString(),
-                  _printDuration(
-                    Duration(
-                      minutes:
-                          Constants.minutesPerEndFourPlayers *
-                          settingsTotalEnds,
-                    ),
-                  ),
+              Constants.minutesPerEndFourPlayers.toString(),
+              _printDuration(
+                Duration(
+                  minutes:
+                      Constants.minutesPerEndFourPlayers * settingsTotalEnds,
                 ),
+              ),
+            ),
           ),
         };
 

--- a/app/lib/widgets/scoreboard/scoreboard_static_number_row.dart
+++ b/app/lib/widgets/scoreboard/scoreboard_static_number_row.dart
@@ -1,4 +1,4 @@
-import 'package:curling_scoreboard/l10n/app_localizations.dart';
+import 'package:curling_scoreboard/l10n/l10n.dart';
 import 'package:flutter/material.dart';
 
 class ScoreboardStaticNumberRow extends StatelessWidget {
@@ -29,7 +29,7 @@ class ScoreboardStaticNumberRow extends StatelessWidget {
             child: StaticNumberContainer(
               number: (currentNumber != numberOfEntries)
                   ? currentNumber.toString()
-                  : AppLocalizations.of(context)!.scoreboardExtraEndLabel,
+                  : context.l10n.scoreboardExtraEndLabel,
               width: endContainerWidth,
               containerColor: containerColor,
             ),

--- a/app/lib/widgets/settings/connect_to_club_dialog.dart
+++ b/app/lib/widgets/settings/connect_to_club_dialog.dart
@@ -1,4 +1,4 @@
-import 'package:curling_scoreboard/l10n/app_localizations.dart';
+import 'package:curling_scoreboard/l10n/l10n.dart';
 import 'package:curling_scoreboard/services/registration_service.dart';
 import 'package:flutter/material.dart';
 
@@ -56,7 +56,7 @@ class _ConnectToClubDialogState extends State<ConnectToClubDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = context.l10n;
 
     return AlertDialog(
       title: Text(l10n.connectToClubDialogTitle),


### PR DESCRIPTION
## Summary

- Adds `app/lib/l10n/l10n.dart` — a `BuildContext.l10n` extension that returns `AppLocalizations.of(this)!`
- Updates all widget files to use `context.l10n.key` in place of `AppLocalizations.of(context)!.key`
- `l10n.dart` re-exports `AppLocalizations` so callers only need a single import

## Why

Dependabot PR [#220](https://github.com/CloudgateStudios/curling_scoreboard/pull/220) bumps `translations_cleaner` from 0.1.1 → 0.2.1. The new version switched from regex to AST-based scanning, which is more accurate — but its `_isLikelyLocalizationTarget` visitor doesn't handle the `!` null-assertion operator. So every call of the form `AppLocalizations.of(context)!.key` looked like an unrecognised expression target and all 24 game-UI translation strings were flagged as unused, causing CI to fail.

The fix uses the `context.l10n` accessor pattern, which `translations_cleaner`'s scanner explicitly looks for (`'l10n'` is in its `_localizationAccessorNames` set). This is also the idiomatic Flutter pattern for localization access.

## Reviewer notes

- No behaviour change — pure refactor of how `AppLocalizations` is accessed
- `flutter analyze` is clean; `translations_cleaner list-unused-terms --abort-on-unused` reports 0 unused keys with 0.2.1
- Once this lands on `main`, PR #220 should pass CI and can be merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)